### PR TITLE
Add guard for classes that lack reflections

### DIFF
--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -93,7 +93,7 @@ module SpeedyAF
 
     def respond_to_missing?(sym, _include_private = false)
       @attrs.key?(sym) ||
-        model.reflections[sym].present? ||
+        model.respond_to?(:reflections) && model.reflections[sym].present? ||
         model.instance_methods.include?(sym)
     end
 

--- a/speedy-af.gemspec
+++ b/speedy-af.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
 
   s.add_dependency 'active-fedora', ['>= 11.0.0']
-  s.add_dependency 'activesupport'
+  s.add_dependency 'activesupport', '< 5.2'
   s.add_development_dependency 'solr_wrapper', '~> 0.15'
   s.add_development_dependency 'fcrepo_wrapper', '~> 0.2'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
For example, instances of ActiveFedora::File don't necessarily respond to :reflections.

Models that have subresources of such classes throw an error when executing respond_to_missing? . 