### PR TITLE
Prefetch related solr documents and then lazily convert to SpeedyAF proxy objects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     executor:
       name: 'samvera/ruby_fcrepo_solr'
       ruby_version: << parameters.ruby_version >>
-      solr_version: 7-alpine
+      solr_version: 8-slim
     environment:
       RAILS_VERSION: << parameters.rails_version >>
     working_directory: ~/project

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,11 +11,15 @@
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 143
+  Exclude:
+    - 'spec/**/*_spec.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 165
+  Exclude:
+    - 'lib/speedy_af/base.rb'
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
@@ -25,7 +29,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
 
 # Offense count: 1
 # Configuration parameters: ExpectMatchingDefinition, CheckDefinitionPathHierarchy, Regex, IgnoreExecutableScripts, AllowedAcronyms.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,16 +24,16 @@ Metrics/ClassLength:
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
-  Max: 9
+  Max: 11
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:
-  Max: 9
+  Max: 11
 
 # Offense count: 1
 Metrics/AbcSize:
-  Max: 37
+  Max: 40
 
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,16 @@ Metrics/ClassLength:
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
-  Max: 7
+  Max: 9
+
+# Offense count: 1
+# Configuration parameters: IgnoredMethods.
+Metrics/PerceivedComplexity:
+  Max: 9
+
+# Offense count: 1
+Metrics/AbcSize:
+  Max: 37
 
 # Offense count: 1
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -126,8 +126,8 @@ module SpeedyAF
               hash[proxy_id] ||= {}
               hash[proxy_id][name] ||= []
               hash[proxy_id][name] << doc
-              hash[proxy_id]["#{name}_ids".to_sym] ||= []
-              hash[proxy_id]["#{name}_ids".to_sym] << doc.id
+              hash[proxy_id]["#{name.to_s.singularize}_ids".to_sym] ||= []
+              hash[proxy_id]["#{name.to_s.singularize}_ids".to_sym] << doc.id
             end
           end
         end
@@ -200,6 +200,7 @@ module SpeedyAF
       if @attrs.key?(sym)
         # Lazy convert the solr document into a speedy_af proxy object
         @attrs[sym] = SpeedyAF::Base.for(@attrs[sym]) if @attrs[sym].is_a?(ActiveFedora::SolrHit)
+        @attrs[sym] = @attrs[sym].map { |doc| SpeedyAF::Base.for(doc) } if @attrs[sym].is_a?(Array) && @attrs[sym].all? { |d| d.is_a?(ActiveFedora::SolrHit) }
         return @attrs[sym]
       end
 

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -55,7 +55,7 @@ module SpeedyAF
         h[doc['id']] = self.for(doc, opts)
       end
 
-      if opts[:load_subresources]
+      if opts[:load_reflections]
         reflections_hash = gather_reflections(hash, opts)
         reflections_hash.each { |parent_id, reflections| hash[parent_id].attrs.merge!(reflections) }
       end

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -7,6 +7,9 @@ module SpeedyAF
 
     SOLR_ALL = 10_000_000
 
+    class_attribute :model_reflections
+    SpeedyAF::Base.model_reflections = {}
+
     attr_reader :attrs, :model
 
     def self.defaults
@@ -134,15 +137,18 @@ module SpeedyAF
     end
 
     def subresource_reflections
-      @subresource_reflections ||= model.reflections.select { |name, reflection| reflection.is_a? ActiveFedora::Reflection::HasSubresourceReflection }
+      SpeedyAF::Base.model_reflections[model] ||= {}
+      SpeedyAF::Base.model_reflections[model][:subresource] ||= model.reflections.select { |name, reflection| reflection.is_a? ActiveFedora::Reflection::HasSubresourceReflection }
     end
 
     def has_many_reflections
-      @has_many_reflections ||= model.reflections.select { |name, reflection| reflection.has_many? && reflection.respond_to?(:predicate_for_solr) }
+      SpeedyAF::Base.model_reflections[model] ||= {}
+      SpeedyAF::Base.model_reflections[model][:has_many] ||= model.reflections.select { |name, reflection| reflection.has_many? && reflection.respond_to?(:predicate_for_solr) }
     end
 
     def belongs_to_reflections
-      @belongs_to_reflections ||= model.reflections.select { |name, reflection| reflection.belongs_to? && reflection.respond_to?(:predicate_for_solr) }
+      SpeedyAF::Base.model_reflections[model] ||= {}
+      SpeedyAF::Base.model_reflections[model][:belongs_to] ||= model.reflections.select { |name, reflection| reflection.belongs_to? && reflection.respond_to?(:predicate_for_solr) }
     end
 
     protected

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -251,6 +251,7 @@ module SpeedyAF
             next unless doc['id'] == proxy.attrs[reflection.predicate_for_solr.to_sym]
             hash[id] ||= {}
             hash[id][name] = self.for(doc, opts)
+            hash[id]["#{name}_id".to_sym] = doc.id
           end
         end
       end
@@ -272,6 +273,8 @@ module SpeedyAF
             hash[id] ||= {}
             hash[id][name] ||= []
             hash[id][name] << self.for(doc, opts)
+            hash[id]["#{name}_ids".to_sym] ||= []
+            hash[id]["#{name}_ids".to_sym] << doc.id
           end
         end
       end
@@ -292,6 +295,7 @@ module SpeedyAF
         next unless subresource_id
         hash[parent_id] ||= {}
         hash[parent_id][subresource_id.to_sym] = self.for(doc, opts)
+        hash[parent_id]["#{subresource_id}_id".to_sym] = doc.id
       end
     end
   end

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -273,7 +273,7 @@ module SpeedyAF
       proxy_hash.each do |id, proxy|
         proxy.has_many_reflections.each do |name, reflection|
           docs.each do |doc|
-            next unless doc.keys.include?("#{reflection.predicate_for_solr}_ssim")
+            next unless Array(doc["#{reflection.predicate_for_solr}_ssim"]).include?(id)
             hash[id] ||= {}
             hash[id][name] ||= []
             hash[id][name] << doc

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -89,7 +89,7 @@ describe SpeedyAF::Base do
       end
 
       context 'preloaded subresources' do
-        let(:book_presenter) { described_class.find(book.id, load_subresources: true) }
+        let(:book_presenter) { described_class.find(book.id, load_reflections: true) }
 
         it 'has already loaded indexed subresources' do
           expect(book_presenter.attrs).to include :indexed_file

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -93,11 +93,12 @@ describe SpeedyAF::Base do
 
         it 'has already loaded indexed subresources' do
           expect(book_presenter.attrs).to include :indexed_file
-          expect(ActiveFedora::SolrService).not_to receive(:query)
+          allow(ActiveFedora::SolrService).to receive(:query).and_call_original
           ipsum_presenter = book_presenter.indexed_file
           expect(ipsum_presenter.model).to eq(IndexedFile)
           expect(ipsum_presenter.content).to eq(indexed_content)
           expect(ipsum_presenter).not_to be_real
+          expect(ActiveFedora::SolrService).not_to have_received(:query)
         end
       end
 

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -88,6 +88,19 @@ describe SpeedyAF::Base do
         expect(ipsum_presenter).not_to be_real
       end
 
+      context 'preloaded subresources' do
+        let(:book_presenter) { described_class.find(book.id, load_subresources: true) }
+
+        it 'has already loaded indexed subresources' do
+          expect(book_presenter.attrs).to include :indexed_file
+          expect(ActiveFedora::SolrService).not_to receive(:query)
+          ipsum_presenter = book_presenter.indexed_file
+          expect(ipsum_presenter.model).to eq(IndexedFile)
+          expect(ipsum_presenter.content).to eq(indexed_content)
+          expect(ipsum_presenter).not_to be_real
+        end
+      end
+
       it 'loads has_many reflections' do
         library.books.create(title: 'Ordered Things II')
         library.save


### PR DESCRIPTION
For objects with a large number of related child or parent objects SpeedyAF's lazy approach can result in hundreds or thousands of solr queries for individual documents.  This PR figures out what all of these will be and fetches all of the documents in one solr request.  It sets attributes on the proxy object with the pre-fetched solr documents then when a relation is later accessed it will cast it into a proxy object.  For a show view of a particular object in production Avalon at IU these changes reduce the amount of time spent in solr requests from about 30s to about 0.5s.