### PR TITLE
Bump version in preparation of release

### DIFF
--- a/lib/speedy_af/version.rb
+++ b/lib/speedy_af/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module SpeedyAF
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
Bumping minor version since this release would allow Rails 6.1 and 7.0 (#10) as well as adds support for prefetching solr docs (#9)