### PR TITLE
Prevent solr error when missing parent ids

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 2.0.2
+        default: 2.5.18
       ffmpeg_version:
         type: string
         default: 4.1.4
@@ -38,18 +38,22 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
-          name: "ruby2-7_rails7-0"
-          ruby_version: "2.7.6"
-          rails_version: "7.0.4"
+          name: "ruby3-3_rails7-2"
+          ruby_version: "3.3.4"
+          rails_version: "7.2.1"
       - bundle_and_test:
-          name: "ruby2-7_rails6-1"
-          ruby_version: "2.7.6"
-          rails_version: "6.1.7"
+          name: "ruby3-2_rails7-1"
+          ruby_version: "3.2.5"
+          rails_version: "7.1.4"
       - bundle_and_test:
-          name: "ruby2-7_rails6-0"
-          ruby_version: "2.7.6"
-          rails_version: "6.0.6"
+          name: "ruby3-1_rails7-1"
+          ruby_version: "3.1.6"
+          rails_version: "7.1.4"
       - bundle_and_test:
-          name: "ruby2-7_rails5-2"
-          ruby_version: "2.7.6"
-          rails_version: "5.2.8.1"
+          name: "ruby3-2_rails7-0"
+          ruby_version: "3.2.5"
+          rails_version: "7.0.8.4"
+      - bundle_and_test:
+          name: "ruby3-1_rails7-0"
+          ruby_version: "3.1.6"
+          rails_version: "7.0.8.4"

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,15 @@ require 'active_fedora/rake_support'
 require 'bundler'
 Bundler::GemHelper.install_tasks
 
+# This is to fix a breaking change with Ruby 3.2 where some methods
+# in fcrepo_wrapper use the removed `File.exists?` alias, preventing
+# tests from being set up.
+class File
+  class << self
+    alias exists? exist?
+  end
+end
+
 require 'rspec/core/rake_task'
 desc 'Run tests only'
 RSpec::Core::RakeTask.new(:rspec) do |spec|

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -93,8 +93,8 @@ module SpeedyAF
       def query_for_belongs_to(proxy_hash, _opts)
         proxy_hash.collect do |_id, proxy|
           proxy.belongs_to_reflections.collect do |_name, reflection|
-            next if proxy.attrs[predicate_for_reflection(reflection).to_sym].blank?
-            "id:#{proxy.attrs[predicate_for_reflection(reflection).to_sym]}"
+            id = proxy.attrs[predicate_for_reflection(reflection).to_sym]
+            id.blank? ? nil : "id:#{id}"
           end.compact
         end.flatten.join(" OR ")
       end

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -92,7 +92,10 @@ module SpeedyAF
 
       def query_for_belongs_to(proxy_hash, _opts)
         proxy_hash.collect do |_id, proxy|
-          proxy.belongs_to_reflections.collect { |_name, reflection| "id:#{proxy.attrs[predicate_for_reflection(reflection).to_sym]}" }
+          proxy.belongs_to_reflections.collect do |_name, reflection|
+            next if proxy.attrs[predicate_for_reflection(reflection).to_sym].blank?
+            "id:#{proxy.attrs[predicate_for_reflection(reflection).to_sym]}"
+          end.compact
         end.flatten.join(" OR ")
       end
 

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -61,7 +61,7 @@ describe SpeedyAF::Base do
     end
 
     it '.to_query' do
-      expect(book.to_query('book_id')).to eq("book_id=#{URI.encode(book.id, /[^\-_.!~*'()a-zA-Z\d;?:@&=+$,\[\]]/)}")
+      expect(book.to_query('book_id')).to eq("book_id=#{URI::Parser.new.escape(book.id, /[^\-_.!~*'()a-zA-Z\d;?:@&=+$,\[\]]/)}")
     end
 
     context 'reflections' do
@@ -103,6 +103,15 @@ describe SpeedyAF::Base do
         expect(book_presenter.library).to be_a(described_class)
         expect(book_presenter.library.model).to eq(library.class)
         expect(book_presenter).not_to be_real
+      end
+
+      context 'missing parent id' do
+        let(:book) { Book.new title: 'Ordered Things', publisher: 'ActiveFedora Performance LLC', library: nil }
+        it 'does not cause belongs_to reflections to error' do
+          expect(book_presenter.library_id).to be_nil
+          expect(book_presenter.library).to be_nil
+          expect(book_presenter).not_to be_real
+        end
       end
 
       context 'preloaded subresources' do


### PR DESCRIPTION
This PR also includes updates to allow testing against Ruby > 3 and Rails > 7