### PR TITLE
Only ask solr for 1 row when using find

### DIFF
--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -42,11 +42,11 @@ module SpeedyAF
       end
 
       def find(id, opts = {})
-        where(%(id:"#{id}"), opts).first
+        where(%(id:"#{id}"), opts.merge(rows: 1)).first
       end
 
       def where(query, opts = {})
-        docs = ActiveFedora::SolrService.query(query, rows: SOLR_ALL)
+        docs = ActiveFedora::SolrService.query(query, rows: opts[:rows] || SOLR_ALL)
         from(docs, opts)
       end
 


### PR DESCRIPTION
This shouldn't change the results at all but only asking for 1 row instead of `SOLR_ALL` can lead to solr performance improvements.  In production we saw requesting 100_000 vs 1_000_000 rows reduced the time queries took to run by an order of magnitude regardless of the number of rows actually being returned.  So only requesting 1 row when we're only returning 1 row should hopefully reduce the response time and strain on solr.