### PR TITLE
Add filtering tests and fix bug in query_for_has_many

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,14 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby3-4_rails8-0"
+          ruby_version: "3.4.5"
+          rails_version: "8.0.1"
+      - bundle_and_test:
+          name: "ruby3-3_rails8-0"
+          ruby_version: "3.3.4"
+          rails_version: "8.0.1"
+      - bundle_and_test:
           name: "ruby3-3_rails7-2"
           ruby_version: "3.3.4"
           rails_version: "7.2.1"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If you have questions or need help, please email [the Hydra community tech list]
   be more mindful of both local resources and Solr request limits.
 * `Base` may not play nicely with language-tagged RDF literals, as ActiveFedora does not
   currently index/encode the language tag into Solr.
+* belongs_to relationships do not respect `include_reflections` filtering and will fetch all
+  belongs_to reflections when the `include_reflections` is not false.
 
 # Acknowledgments
 

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -115,7 +115,11 @@ module SpeedyAF
 
       def query_for_has_many(proxy_hash, opts)
         proxy_hash.collect do |id, proxy|
-          proxy.has_many_reflections(only: opts[:load_reflections]).collect { |_name, reflection| "#{predicate_for_reflection(reflection)}_ssim:#{id}" }
+          proxy.has_many_reflections(only: opts[:load_reflections]).collect do |_name, reflection|
+            query = "#{predicate_for_reflection(reflection)}_ssim:#{id}"
+            query = "(#{query} AND has_model_ssim:#{reflection.class_name})" if opts[:load_reflections].is_a?(Array)
+            query
+          end
         end.flatten.join(" OR ")
       end
 

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -117,7 +117,7 @@ module SpeedyAF
         proxy_hash.collect do |id, proxy|
           proxy.has_many_reflections(only: opts[:load_reflections]).collect do |_name, reflection|
             query = "#{predicate_for_reflection(reflection)}_ssim:#{id}"
-            query = "(#{query} AND has_model_ssim:#{reflection.class_name})" if opts[:load_reflections].is_a?(Array)
+            query = "(#{query} AND has_model_ssim:#{reflection.class_name})"
             query
           end
         end.flatten.join(" OR ")

--- a/lib/speedy_af/base.rb
+++ b/lib/speedy_af/base.rb
@@ -93,8 +93,8 @@ module SpeedyAF
       def query_for_belongs_to(proxy_hash, opts)
         proxy_hash.collect do |_id, proxy|
           proxy.belongs_to_reflections(only: opts[:load_reflections]).collect do |_name, reflection|
-            id = proxy.attrs[predicate_for_reflection(reflection).to_sym]
-            id.blank? ? nil : "id:#{id}"
+            ids = proxy.attrs[predicate_for_reflection(reflection).to_sym]
+            ids.blank? ? nil : Array(ids).collect { |id| "id:#{id}" }.join(" OR ")
           end.compact
         end.flatten.join(" OR ")
       end
@@ -103,7 +103,7 @@ module SpeedyAF
         hash = {}
         proxy_hash.each do |proxy_id, proxy|
           proxy.belongs_to_reflections.each do |name, reflection|
-            doc = docs.find { |d| d.id == proxy.attrs[predicate_for_reflection(reflection).to_sym] }
+            doc = docs.find { |d| proxy.attrs[predicate_for_reflection(reflection).to_sym].include?(d.id) && d["has_model_ssim"].include?(reflection.class_name) }
             next unless doc
             hash[proxy_id] ||= {}
             hash[proxy_id][name] = doc
@@ -129,7 +129,7 @@ module SpeedyAF
         docs.each do |doc|
           has_many_reflections.each do |name, reflection|
             Array(doc["#{predicate_for_reflection(reflection)}_ssim"]).each do |proxy_id|
-              next unless proxy_hash.key?(proxy_id)
+              next unless proxy_hash.key?(proxy_id) && doc["has_model_ssim"].include?(reflection.class_name)
               hash[proxy_id] ||= {}
               hash[proxy_id][name] ||= []
               hash[proxy_id][name] << doc
@@ -203,7 +203,6 @@ module SpeedyAF
 
     def method_missing(sym, *args)
       return real_object.send(sym, *args) if real?
-
       if @attrs.key?(sym)
         # Lazy convert the solr document into a speedy_af proxy object
         @attrs[sym] = SpeedyAF::Base.for(@attrs[sym]) if @attrs[sym].is_a?(ActiveFedora::SolrHit)
@@ -279,7 +278,7 @@ module SpeedyAF
       attr_name, type, _stored, _indexed, _multi = k.scan(/^(.+)_(.+)(s)(i?)(m?)$/).first
       return [k, v] if attr_name.nil?
       value = Array(v).map { |m| transforms.fetch(type, transforms[nil]).call(m) }
-      value = value.first unless @model.respond_to?(:properties) && multiple?(@model.properties[attr_name])
+      value = value.first unless reflection_solr_fields(@model).include?(attr_name) || (@model.respond_to?(:properties) && multiple?(@model.properties[attr_name]))
       [attr_name, value]
     end
 
@@ -287,10 +286,15 @@ module SpeedyAF
       prop.present? && prop.respond_to?(:multiple?) && prop.multiple?
     end
 
+    def reflection_solr_fields(model)
+      return [] unless model.respond_to?(:reflections)
+      model.reflections.values.select { |v| v.belongs_to? && v.respond_to?(:predicate_for_solr) }.collect(&:predicate_for_solr)
+    end
+
     def load_from_reflection(reflection, ids_only = false)
       return load_through_reflection(reflection, ids_only) if reflection.options.key?(:through)
-      return load_belongs_to_reflection(reflection.predicate_for_solr, ids_only) if reflection.belongs_to? && reflection.respond_to?(:predicate_for_solr)
-      return load_has_many_reflection(reflection.predicate_for_solr, ids_only) if reflection.has_many? && reflection.respond_to?(:predicate_for_solr)
+      return load_belongs_to_reflection(reflection, ids_only) if reflection.belongs_to? && reflection.respond_to?(:predicate_for_solr)
+      return load_has_many_reflection(reflection, ids_only) if reflection.has_many? && reflection.respond_to?(:predicate_for_solr)
       return load_subresource_content(reflection) if reflection.is_a?(ActiveFedora::Reflection::HasSubresourceReflection)
       # :nocov:
       raise NotAvailable, "`#{reflection.name}' cannot be quick-loaded. Falling back to model."
@@ -321,14 +325,18 @@ module SpeedyAF
       ids
     end
 
-    def load_belongs_to_reflection(predicate, ids_only = false)
-      id = @attrs[predicate.to_sym]
-      return id if ids_only
-      Base.find(id)
+    def load_belongs_to_reflection(reflection, ids_only = false)
+      id = @attrs[reflection.predicate_for_solr.to_sym]
+      return id.first if ids_only && Array(id).size == 1
+      return if id.blank?
+      query = Array(id).collect { |i| "id:#{i}" }.join(" OR ")
+      query = "(#{query}) AND has_model_ssim:#{reflection.class_name}"
+      obj = Base.where(query, rows: 1).first
+      ids_only ? obj&.id : obj
     end
 
-    def load_has_many_reflection(predicate, ids_only = false)
-      query = %(#{predicate}_ssim:#{id})
+    def load_has_many_reflection(reflection, ids_only = false)
+      query = "#{reflection.predicate_for_solr}_ssim:#{id} AND has_model_ssim:#{reflection.class_name}"
       return Base.where(query) unless ids_only
       docs = ActiveFedora::SolrService.query query, rows: SOLR_ALL
       docs.collect { |doc| doc['id'] }

--- a/spec/fixture_classes.rb
+++ b/spec/fixture_classes.rb
@@ -48,7 +48,7 @@ class Comic < ActiveFedora::Base
   include TitleBehavior
 
   belongs_to :library, predicate: ::RDF::Vocab::DC.isPartOf
-  belongs_to :comic_shop, predicate: ::RDF::Vocab::DC.isRequiredBy
+  belongs_to :comic_shop, predicate: ::RDF::Vocab::DC.isPartOf
   property :title, predicate: ::RDF::Vocab::DC.title, multiple: false do |index|
     index.as :stored_searchable
   end
@@ -58,12 +58,12 @@ class Comic < ActiveFedora::Base
 end
 
 class Library < ActiveFedora::Base
-  has_many :books, predicate: ::RDF::Vocab::DC.isPartOf
-  has_many :comics, predicate: ::RDF::Vocab::DC.isRequiredBy
+  has_many :books, class_name: 'Book', predicate: ::RDF::Vocab::DC.isPartOf
+  has_many :comics, class_name: 'Comic', predicate: ::RDF::Vocab::DC.isPartOf
 end
 
 class ComicShop < ActiveFedora::Base
-  has_many :comics, predicate: ::RDF::Vocab::DC.isRequiredBy
+  has_many :comics, predicate: ::RDF::Vocab::DC.isPartOf
 end
 
 module SpeedySpecs

--- a/spec/fixture_classes.rb
+++ b/spec/fixture_classes.rb
@@ -3,6 +3,10 @@ class IndexedFile < ActiveFedora::File
   include SpeedyAF::IndexedContent
 end
 
+class SampleResource < ActiveFedora::File
+  include SpeedyAF::IndexedContent
+end
+
 class Chapter < ActiveFedora::Base
   property :title, predicate: ::RDF::Vocab::DC.title, multiple: false do |index|
     index.as :stored_searchable
@@ -12,18 +16,23 @@ class Chapter < ActiveFedora::Base
   end
 end
 
-module DowncaseBehavior
+module TitleBehavior
   def lowercase_title
     title.downcase
+  end
+
+  def uppercase_title
+    title.upcase
   end
 end
 
 class Book < ActiveFedora::Base
-  include DowncaseBehavior
+  include TitleBehavior
   include SpeedyAF::OrderedAggregationIndex
 
   belongs_to :library, predicate: ::RDF::Vocab::DC.isPartOf
   has_subresource 'indexed_file', class_name: 'IndexedFile'
+  has_subresource 'descMetadata', class_name: 'SampleResource'
   has_subresource 'unindexed_file', class_name: 'ActiveFedora::File'
   property :title, predicate: ::RDF::Vocab::DC.title, multiple: false do |index|
     index.as :stored_searchable
@@ -33,14 +42,28 @@ class Book < ActiveFedora::Base
   end
   ordered_aggregation :chapters, through: :list_source
   indexed_ordered_aggregation :chapters
+end
 
-  def uppercase_title
-    title.upcase
+class Comic < ActiveFedora::Base
+  include TitleBehavior
+
+  belongs_to :library, predicate: ::RDF::Vocab::DC.isPartOf
+  belongs_to :comic_shop, predicate: ::RDF::Vocab::DC.isRequiredBy
+  property :title, predicate: ::RDF::Vocab::DC.title, multiple: false do |index|
+    index.as :stored_searchable
+  end
+  property :publisher, predicate: ::RDF::Vocab::DC.publisher, multiple: false do |index|
+    index.as :stored_searchable
   end
 end
 
 class Library < ActiveFedora::Base
   has_many :books, predicate: ::RDF::Vocab::DC.isPartOf
+  has_many :comics, predicate: ::RDF::Vocab::DC.isRequiredBy
+end
+
+class ComicShop < ActiveFedora::Base
+  has_many :comics, predicate: ::RDF::Vocab::DC.isRequiredBy
 end
 
 module SpeedySpecs

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 require 'rdf/vocab/dc'
 
 describe SpeedyAF::Base do
-  before { load_fixture_classes!   }
+  before { load_fixture_classes! }
   after  { unload_fixture_classes! }
 
   let!(:library) { Library.create }
+  let!(:comic_shop) { ComicShop.create }
   let!(:book) { Book.new title: 'Ordered Things', publisher: 'ActiveFedora Performance LLC', library: library }
+  let!(:comic) { Comic.new title: 'Vestibulum velit nulla', publisher: 'SpeedyAF LLC', library: library, comic_shop: comic_shop }
   let!(:chapters) do
     [
       Chapter.create(title: 'Chapter 3', contributor: ['Hopper', 'Lovelace', 'Johnson']),
@@ -31,12 +33,21 @@ describe SpeedyAF::Base do
     Nigh tofth eliv ingdead.
     IPSUM
   end
+  let!(:metadata) do
+    <<-IPSUM
+    In scelerisque volutpat rutrum. Phasellus dictum velit at orci luctus convallis. Nulla rutrum
+    eget libero at sodales. Suspendisse potenti. Donec ut lobortis mi, ut venenatis diam. Phasellus
+    mi felis, cursus at lacinia vitae, aliquam vitae eros. Suspendisse tincidunt a massa in
+    condimentum. Nulla finibus risus quam, vel elementum enim sodales at.
+    IPSUM
+  end
   let(:book_presenter) { described_class.find(book.id) }
 
   context 'lightweight presenter' do
     before do
       book.indexed_file.content = indexed_content
       book.unindexed_file.content = unindexed_content
+      book.descMetadata.content = metadata
       book.chapters = chapters
       book.ordered_chapters = chapters.sort_by(&:title)
       book.save!
@@ -66,6 +77,7 @@ describe SpeedyAF::Base do
 
     context 'reflections' do
       let!(:library_presenter) { described_class.find(library.id) }
+      let!(:comic_shop_presenter) { described_class.find(comic_shop.id) }
 
       it 'loads via indexed proxies' do
         expect(book_presenter.chapter_ids).to match_array(book.chapter_ids)
@@ -82,10 +94,14 @@ describe SpeedyAF::Base do
 
       it 'loads indexed subresources' do
         ipsum_presenter = book_presenter.indexed_file
+        lorem_presenter = book_presenter.descMetadata
         expect(ipsum_presenter.model).to eq(IndexedFile)
+        expect(lorem_presenter.model).to eq(SampleResource)
         expect(ipsum_presenter.content).to eq(indexed_content)
+        expect(lorem_presenter.content).to eq(metadata)
         expect(book_presenter).not_to be_real
         expect(ipsum_presenter).not_to be_real
+        expect(lorem_presenter).not_to be_real
       end
 
       it 'loads has_many reflections' do
@@ -151,13 +167,57 @@ describe SpeedyAF::Base do
           expect(book_presenter).not_to be_real
           expect(ActiveFedora::SolrService).not_to have_received(:query)
         end
+
+        context 'filtering' do
+          let(:book_presenter) { described_class.find(book.id, load_reflections: [:indexed_file]) }
+          let(:comic_presenter) { described_class.find(comic.id, load_reflections: [:comic_shop]) }
+          before { comic.save! }
+
+          it 'has already loaded filtered subresources' do
+            expect(book_presenter.attrs).to include :indexed_file
+            expect(book_presenter.attrs).to_not include :descMetadata
+            allow(ActiveFedora::SolrService).to receive(:query).and_call_original
+            ipsum_presenter = book_presenter.indexed_file
+            expect(ipsum_presenter.model).to eq(IndexedFile)
+            expect(ipsum_presenter.content).to eq(indexed_content)
+            expect(ipsum_presenter).not_to be_real
+            expect(ActiveFedora::SolrService).not_to have_received(:query)
+          end
+
+          it 'has already loaded filtered has_many reflections' do
+            library.books.create(title: 'Ordered Things II')
+            library.save
+            book_ids = library.book_ids
+            library_presenter = described_class.find(library.id, load_reflections: [:books])
+            expect(library_presenter.attrs).to include :books
+            expect(library_presenter.attrs).to_not include :comics
+            allow(ActiveFedora::SolrService).to receive(:query).and_call_original
+            presenter = library_presenter.books
+            expect(presenter.length).to eq(2)
+            expect(presenter.all? { |bp| bp.is_a?(described_class) }).to be_truthy
+            expect(library_presenter.book_ids).to match_array(book_ids)
+            expect(library_presenter).not_to be_real
+            expect(ActiveFedora::SolrService).not_to have_received(:query)
+          end
+
+          it 'has already loaded filtered belongs_to reflections' do
+            expect(comic_presenter.attrs).to include :comic_shop
+            expect(comic_presenter.attrs).to_not include :library
+            allow(ActiveFedora::SolrService).to receive(:query).and_call_original
+            expect(comic_presenter.comic_shop_id).to eq(comic_shop.id)
+            expect(comic_presenter.comic_shop).to be_a(described_class)
+            expect(comic_presenter.comic_shop.model).to eq(comic_shop.class)
+            expect(comic_presenter).not_to be_real
+            expect(ActiveFedora::SolrService).not_to have_received(:query)
+          end
+        end
       end
     end
 
     context 'configuration' do
       before do
         described_class.config Book do
-          include DowncaseBehavior
+          include TitleBehavior
           self.defaults = { foo: 'bar!' }
         end
 

--- a/spec/integration/base_spec.rb
+++ b/spec/integration/base_spec.rb
@@ -42,6 +42,7 @@ describe SpeedyAF::Base do
     IPSUM
   end
   let(:book_presenter) { described_class.find(book.id) }
+  let(:comic_presenter) { described_class.find(comic.id) }
 
   context 'lightweight presenter' do
     before do
@@ -106,19 +107,26 @@ describe SpeedyAF::Base do
 
       it 'loads has_many reflections' do
         library.books.create(title: 'Ordered Things II')
+        library.comics.create(title: 'Comet in Moominland')
         library.save
-        presenter = library_presenter.books
-        expect(presenter.length).to eq(2)
-        expect(presenter.all? { |bp| bp.is_a?(described_class) }).to be_truthy
+        expect(library_presenter.books.length).to eq(2)
+        expect(library_presenter.books.all? { |bp| bp.is_a?(described_class) }).to be_truthy
         expect(library_presenter.book_ids).to match_array(library.book_ids)
+        expect(library_presenter.comics.length).to eq(1)
+        expect(library_presenter.comics.all? { |bp| bp.is_a?(described_class) }).to be_truthy
+        expect(library_presenter.comic_ids).to match_array(library.comic_ids)
         expect(library_presenter).not_to be_real
       end
 
       it 'loads belongs_to reflections' do
-        expect(book_presenter.library_id).to eq(library.id)
-        expect(book_presenter.library).to be_a(described_class)
-        expect(book_presenter.library.model).to eq(library.class)
-        expect(book_presenter).not_to be_real
+        comic.save!
+        expect(comic_presenter.library_id).to eq(library.id)
+        expect(comic_presenter.library).to be_a(described_class)
+        expect(comic_presenter.library.model).to eq(library.class)
+        expect(comic_presenter.comic_shop_id).to eq(comic_shop.id)
+        expect(comic_presenter.comic_shop).to be_a(described_class)
+        expect(comic_presenter.comic_shop.model).to eq(comic_shop.class)
+        expect(comic_presenter).not_to be_real
       end
 
       context 'missing parent id' do
@@ -145,15 +153,22 @@ describe SpeedyAF::Base do
 
         it 'has already loaded has_many reflections' do
           library.books.create(title: 'Ordered Things II')
+          library.comics.create(title: 'Comet in Moominland')
           library.save
           book_ids = library.book_ids
+          comic_ids = library.comic_ids
           library_presenter = described_class.find(library.id, load_reflections: true)
           expect(library_presenter.attrs).to include :books
+          expect(library_presenter.attrs).to include :comics
           allow(ActiveFedora::SolrService).to receive(:query).and_call_original
-          presenter = library_presenter.books
-          expect(presenter.length).to eq(2)
-          expect(presenter.all? { |bp| bp.is_a?(described_class) }).to be_truthy
+          books_presenter = library_presenter.books
+          comics_presenter = library_presenter.comics
+          expect(books_presenter.length).to eq(2)
+          expect(books_presenter.all? { |bp| bp.is_a?(described_class) }).to be_truthy
+          expect(comics_presenter.length).to eq(1)
+          expect(comics_presenter.all? { |bp| bp.is_a?(described_class) }).to be_truthy
           expect(library_presenter.book_ids).to match_array(book_ids)
+          expect(library_presenter.comic_ids).to match_array(comic_ids)
           expect(library_presenter).not_to be_real
           expect(ActiveFedora::SolrService).not_to have_received(:query)
         end
@@ -200,13 +215,17 @@ describe SpeedyAF::Base do
             expect(ActiveFedora::SolrService).not_to have_received(:query)
           end
 
-          it 'has already loaded filtered belongs_to reflections' do
+          it 'has already loaded belongs_to reflections and does not filter' do
             expect(comic_presenter.attrs).to include :comic_shop
-            expect(comic_presenter.attrs).to_not include :library
+            expect(comic_presenter.attrs).to include :library
             allow(ActiveFedora::SolrService).to receive(:query).and_call_original
             expect(comic_presenter.comic_shop_id).to eq(comic_shop.id)
             expect(comic_presenter.comic_shop).to be_a(described_class)
             expect(comic_presenter.comic_shop.model).to eq(comic_shop.class)
+            expect(comic_presenter).not_to be_real
+            expect(comic_presenter.library_id).to eq(library.id)
+            expect(comic_presenter.library).to be_a(described_class)
+            expect(comic_presenter.library.model).to eq(library.class)
             expect(comic_presenter).not_to be_real
             expect(ActiveFedora::SolrService).not_to have_received(:query)
           end


### PR DESCRIPTION
If a parent class contains multiple `has_many` entries that all use the same predicate the `query_for_has_many` would still generate the list of reflections containing all classes that match the predicate instead of only returning reflections from the filtered for class(es). Adding a "has_model_ssim" check to the query when filtering is occurring prevents the errant results.